### PR TITLE
Make resampled data frames accessible with $ or [[

### DIFF
--- a/R/permute.R
+++ b/R/permute.R
@@ -100,7 +100,6 @@ as.data.frame.permutation <- function(x, ...) {
   ret <- x$data
   indices <- x$idx
   for (col in x$columns) {
-    print(col)
     ret[[col]] <- ret[[col]][indices]
   }
   ret

--- a/R/permute.R
+++ b/R/permute.R
@@ -1,0 +1,135 @@
+#' Generate \code{n} permutation replicates.
+#'
+#' A permutation test involves permuting one or more variables in a data set
+#' before performing the test, in order to break any existing relationships
+#' and simulate the null hypothesis. One can then compare the true statistic
+#' to the generated distribution of null statistics.
+#'
+#' @inheritParams resample_partition
+#' @param columns Columns to permute
+#' @param n Number of permutations to generate
+#' @param id Name of variable that gives each model a unique integer id
+#'
+#' @return A data frame with \code{n} rows and one column: \code{perm}
+#' @export
+#' @examples
+#'
+#' library(purrr)
+#' library(broom)
+#' perms <- permute(mtcars, "mpg", 100)
+#'
+#' models <- map(perms$perm, ~ lm(mpg ~ wt, data = .))
+#' glanced <- map_df(models, glance, .id = "id")
+#'
+#' # distribution of null permutation statistics
+#' hist(glanced$statistic)
+#' # confirm these are roughly uniform p-values
+#' hist(glanced$p.value)
+#'
+#' # test against the unpermuted model to get a permutation p-value
+#' mod <- lm(mpg ~ wt, mtcars)
+#' mean(glanced$statistic > glance(mod)$statistic)
+#'
+#' @export
+permute <- function(data, columns, n, id = ".id") {
+  perm <- purrr::rerun(n, resample_permutation(data, columns))
+
+  df <- tibble::data_frame(perm = perm)
+  df[[id]] <- id(n)
+  df
+}
+
+#' Create a resampled permutation of a data frame
+#'
+#' @param data A data frame
+#' @param columns Columns to be permuted
+#' @param idx Indices to permute by. If not given, generates them randomly
+#'
+#' @return A permutation object; use as.data.frame to convert to a permuted
+#' data frame
+#'
+#' @export
+resample_permutation <- function(data, columns, idx = NULL) {
+  if (is.null(idx)) {
+    idx <- sample.int(nrow(data))
+  }
+
+  if (!is.data.frame(data)) {
+    stop("`data` must be a data frame.", call. = FALSE)
+  }
+  if (!is.character(columns) ||
+      !(all(columns %in% colnames(data)))) {
+    stop("`columns` must be a vector of column names in `data`", call. = FALSE)
+  }
+  if (!is.integer(idx) || length(idx) != nrow(data)) {
+    stop("`idx` must be an integer vector with the same length as there are ",
+         "rows in `data`", call. = FALSE)
+  }
+
+  structure(
+    list(
+      data = data,
+      columns = columns,
+      idx = idx
+    ),
+    class = "permutation"
+  )
+}
+
+#' @export
+print.permutation <- function(x, ...) {
+  n <- length(x$idx)
+  if (n > 10) {
+    id10 <- c(x$idx[1:10], "...")
+  } else {
+    id10 <- x$idx
+  }
+
+  cat("<", obj_sum.permutation(x), "> ", paste(id10, collapse = ", "), "\n",
+      sep = ""
+  )
+}
+
+#' @export
+as.integer.permutation <- function(x, ...) {
+  x$idx
+}
+
+#' @export
+as.data.frame.permutation <- function(x, ...) {
+  ret <- x$data
+  indices <- x$idx
+  for (col in x$columns) {
+    print(col)
+    ret[[col]] <- ret[[col]][indices]
+  }
+  ret
+}
+
+#' @export
+dim.permutation <- function(x, ...) {
+  c(length(x$idx), ncol(x$data))
+}
+
+#' @importFrom tibble obj_sum
+#' @method obj_sum resample
+#' @export
+obj_sum.permutation <- function(x, ...) {
+  paste0("permutation (", paste0(x$columns, collapse = ", "), ") [",
+         big_mark(nrow(x)), " x ", big_mark(ncol(x)), "]")
+}
+
+`$.permutation` <- function(x, name) {
+  x[[name]]
+}
+
+`[[.permutation` <- function(x, name, ...) {
+  unclassed <- unclass(x)
+  if (name == "data" || name == "columns" || name == "idx") {
+    unclassed[[name]]
+  } else if (name %in% unclassed$columns) {
+    unclassed$data[[name]][unclassed$idx]
+  } else {
+    unclassed$data[[name]]
+  }
+}

--- a/R/resample.R
+++ b/R/resample.R
@@ -75,3 +75,16 @@ dim.resample <- function(x, ...) {
 obj_sum.resample <- function(x, ...) {
   paste0("resample [", big_mark(nrow(x)), " x ", big_mark(ncol(x)), "]")
 }
+
+`$.resample` <- function(x, name) {
+  x[[name]]
+}
+
+`[[.resample` <- function(x, name, ...) {
+  unclassed <- unclass(x)
+  if (name == "data" || name == "idx") {
+    unclassed[[name]]
+  } else {
+    unclassed$data[[name]][unclassed$idx]
+  }
+}

--- a/tests/testthat/test-permute.R
+++ b/tests/testthat/test-permute.R
@@ -1,0 +1,28 @@
+context("permute")
+
+test_that("resample_permutation generates permutations of one column", {
+  p <- resample_permutation(mtcars, "mpg")
+
+  expect_is(p, "permutation")
+
+  expect_true(any(p$mpg != mtcars$mpg))
+  expect_equal(sort(p$mpg), sort(mtcars$mpg))
+  expect_equal(p$cyl, mtcars$cyl)
+  expect_equal(p$am, mtcars$am)
+})
+
+test_that("permute generates n permutations", {
+  ps <- permute(mtcars, "mpg", 100)
+
+  expect_is(ps, "tbl_df")
+  expect_equal(nrow(ps), 100)
+  expect_is(ps$perm, "list")
+
+  p <- ps$perm[[1]]
+  expect_is(p, "permutation")
+
+  expect_true(any(p$mpg != mtcars$mpg))
+  expect_equal(sort(p$mpg), sort(mtcars$mpg))
+  expect_equal(p$cyl, mtcars$cyl)
+  expect_equal(p$am, mtcars$am)
+})

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -1,0 +1,18 @@
+context("resample")
+
+test_that("resample objects can be accessed with as.data.frame", {
+  r <- resample(mtcars, 32:1)
+
+  expect_is(r, "resample")
+
+  d <- as.data.frame(r)
+  expect_is(d, "data.frame")
+  expect_equal(d$mpg, rev(mtcars$mpg))
+})
+
+
+test_that("resample objects can be accessed with $ or [[", {
+  r <- resample(mtcars, 32:1)
+  expect_equal(r$mpg, rev(mtcars$mpg))
+  expect_equal(r[["mpg"]], rev(mtcars$mpg))
+})


### PR DESCRIPTION
I've found that people (including myself!) expect `resample` objects to be accessible with $ or [[ (examples in [this GitHub issue](https://github.com/dgrtwo/broom/issues/25#issuecomment-248080175), [this application](https://twitter.com/drob/status/776844759847542789), and some private correspondence).

This change (along with some unit tests) should make that possible while still allowing idx and data to be accessed normally.
