### PR TITLE
Reproducible cross validation with seed

### DIFF
--- a/man/crossv_mc.Rd
+++ b/man/crossv_mc.Rd
@@ -5,9 +5,9 @@
 \alias{crossv_mc}
 \title{Generate cross-validated test-training pairs}
 \usage{
-crossv_mc(data, n, test = 0.2, id = ".id")
+crossv_mc(data, n, test = 0.2, id = ".id", seed = NULL)
 
-crossv_kfold(data, k = 5, id = ".id")
+crossv_kfold(data, k = 5, id = ".id", seed = NULL)
 }
 \arguments{
 \item{data}{A data frame}
@@ -18,6 +18,8 @@ crossv_kfold(data, k = 5, id = ".id")
 (a double).}
 
 \item{id}{Name of variable that gives each model a unique integer id.}
+
+\item{seed}{An integer to seed random sampling, making result reproducible.}
 
 \item{k}{Number of folds (an integer).}
 }
@@ -41,5 +43,13 @@ cv2 <- crossv_mc(mtcars, 100)
 models <- map(cv2$train, ~ lm(mpg ~ wt, data = .))
 errs <- map2_dbl(models, cv2$test, rmse)
 hist(errs)
+
+# Set seed to make results reproducible
+cv1 <- crossv_kfold(mtcars, 5, seed = 287)
+cv2 <- crossv_kfold(mtcars, 5, seed = 287)
+cv3 <- crossv_kfold(mtcars, 5, seed = 100)  # will be different
+
+identical(cv1, cv2)
+identical(cv1, cv3)
 }
 

--- a/tests/testthat/test-cross_validation.R
+++ b/tests/testthat/test-cross_validation.R
@@ -1,0 +1,27 @@
+context("cross validation")
+
+df <- data.frame(x = 1:100)
+
+test_that("seed enables reproducible results", {
+
+  expect_identical(
+    crossv_mc(df, n = 3, seed = 10),
+    crossv_mc(df, n = 3, seed = 10)
+  )
+
+  expect_false(identical(
+    crossv_mc(df, n = 3, seed = 10),
+    crossv_mc(df, n = 3, seed = 234)
+  ))
+
+  expect_identical(
+    crossv_kfold(df, seed = 10),
+    crossv_kfold(df, seed = 10)
+  )
+
+  expect_false(identical(
+    crossv_kfold(df, seed = 10),
+    crossv_kfold(df, seed = 234)
+  ))
+
+})


### PR DESCRIPTION
I've had a need to reproduce cross-validation pairs. However, the cross-validation functions (`crossv_mc` and `crossv_kfold`) cannot be made reproducible with external `set.seed`.

```r
# Not reproducible
set.seed(101)
crossv_kfold(mtcars, k = 5)
```

The proposed changes place `set.seed()` in the functions and introduce a `seed` argument, thus enabling reproducible results.

```r
# Reproducible
crossv_kfold(mtcars, k = 5, seed = 101)
```

Not sure if this fits with the package, but seemed simple enough to implement.