### PR TITLE
Add tests of resample's arguments and testthat tests for resample

### DIFF
--- a/R/resample.R
+++ b/R/resample.R
@@ -32,6 +32,13 @@ resample <- function(data, idx) {
   } else if (!is.integer(idx)) {
     stop("`idx` must be an integer vector.", call. = FALSE)
   }
+  if (any(is.na(idx))) {
+    stop("`idx` cannot be `NA`", call. = FALSE)
+  }
+  if (any((idx < 1) | (idx > nrow(data)))) {
+    stop("All values of `idx` must be between 1 and `nrow(data)`",
+         call. = FALSE)
+  }
 
   structure(
     list(

--- a/R/resample.R
+++ b/R/resample.R
@@ -27,7 +27,9 @@ resample <- function(data, idx) {
   if (!is.data.frame(data)) {
     stop("`data` must be a data frame.", call. = FALSE)
   }
-  if (!is.integer(idx)) {
+  if (is.numeric(idx)) {
+    idx <- as.integer(idx)
+  } else if (!is.integer(idx)) {
     stop("`idx` must be an integer vector.", call. = FALSE)
   }
 

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -35,10 +35,16 @@ test_that("resample raises error for invalid `idx`", {
   expect_error(resample(df, c(nrow(df) + 1L, 2:3)), regexp = msg)
 })
 
-test_that("resample raises error for invalid `idx`", {
+test_that("resample raises error for missing `idx`", {
   df <- tibble::tibble(a = 1:10)
   expect_error(resample(df, c(NA_integer_, 2:3)),
                regexp = paste0("`idx` cannot be `NA`"))
+})
+
+test_that("resample works with empty idx", {
+  x <- resample(tibble::tibble(a = 1:10), integer(0))
+  expect_is(x, "resample")
+  expect_identical(dim(x), c(0L, 1L))
 })
 
 

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -28,6 +28,20 @@ test_that("resample raises error for non-numeric `idx`", {
                regexp = "`idx` must be an integer vector")
 })
 
+test_that("resample raises error for invalid `idx`", {
+  msg <- paste0("All values of `idx` must be between 1 and `nrow\\(data\\)`")
+  df <- tibble::tibble(a = 1:10)
+  expect_error(resample(df, c(0L, 2:3)), regexp = msg)
+  expect_error(resample(df, c(nrow(df) + 1L, 2:3)), regexp = msg)
+})
+
+test_that("resample raises error for invalid `idx`", {
+  df <- tibble::tibble(a = 1:10)
+  expect_error(resample(df, c(NA_integer_, 2:3)),
+               regexp = paste0("`idx` cannot be `NA`"))
+})
+
+
 test_that("as.data.frame.resample works", {
   df <- tibble::tibble(a = 1:5)
   idx <- c(3, 2)

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -47,6 +47,13 @@ test_that("resample works with empty idx", {
   expect_identical(dim(x), c(0L, 1L))
 })
 
+test_that("resample works with empty idx and empty data frame", {
+  x <- resample(tibble::tibble(), integer())
+  expect_is(x, "resample")
+  expect_identical(dim(x), c(0L, 0L))
+})
+
+
 
 test_that("as.data.frame.resample works", {
   df <- tibble::tibble(a = 1:5)

--- a/tests/testthat/test-resample.R
+++ b/tests/testthat/test-resample.R
@@ -1,0 +1,47 @@
+context("resample")
+
+test_that("resample works as expected", {
+  df <- tibble::tibble(a = 1:5)
+  idx <- 2:3
+  foo <- resample(df, idx)
+  expect_is(foo, "resample")
+  expect_identical(foo$data, df)
+  expect_identical(as.integer(foo), idx)
+})
+
+test_that("resample works with numeric idx arg", {
+  df <- tibble::tibble(a = 1:5)
+  idx <- c(3, 2)
+  foo <- resample(df, idx)
+  expect_is(foo, "resample")
+  expect_identical(foo$data, df)
+  expect_identical(as.integer(foo), as.integer(idx))
+})
+
+test_that("resample raises error for non-data.frame `data`", {
+  expect_error(resample(1:5, tibble::tibble(a = 1)),
+               regexp = "`data` must be a data frame")
+})
+
+test_that("resample raises error for non-numeric `idx`", {
+  expect_error(resample(tibble::tibble(a = 1:10), c("1", "2")),
+               regexp = "`idx` must be an integer vector")
+})
+
+test_that("as.data.frame.resample works", {
+  df <- tibble::tibble(a = 1:5)
+  idx <- c(3, 2)
+  expect_identical(as.data.frame(resample(df, idx)), df[idx, ])
+})
+
+test_that("as.integer.resample works", {
+  df <- tibble::tibble(a = 1:5)
+  idx <- c(3L, 2L)
+  expect_identical(as.integer(resample(df, idx)), idx)
+})
+
+test_that("dim.resample works", {
+  df <- tibble::tibble(a = 1:5)
+  idx <- c(3L, 2L)
+  expect_identical(dim(resample(df, idx)), c(2L, 1L))
+})


### PR DESCRIPTION
This adds several updates 

- allow numeric`idx` arguments for resample. I was getting burned too many times by errors from seemingly reasonable: `resample(data, c(1, 5)`. Now the code checks for numeric `idx` and converts them to integers.
- raise error if any missing values in `idx`
- raise error if any values of `idx` are outside the range: 1 to the number of rows of `data`.
- full suite of tests for `resample()` and its methods